### PR TITLE
fix: Isolate BUILD_TESTS option and test target name

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -B ${{github.workspace}}/build -DBUILD_TESTS=ON -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/install
+      run: cmake -B ${{github.workspace}}/build -DCPP_COMMON_UTILS_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/install
 
     - name: Build
       # Build your program with the given configuration
@@ -46,4 +46,4 @@ jobs:
       working-directory: ${{github.workspace}}/install
       env:
           LD_LIBRARY_PATH: ${{ github.workspace }}/install/lib
-      run: ./tests/main --gtest_filter=*.*
+      run: ./tests/cpp_common_utils_tests --gtest_filter=*.*

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,7 +7,7 @@
   "cmake.generator": "Ninja",
   "cmake.exportCompileCommandsFile": true,
   "cmake.configureArgs": [
-    "-DBUILD_TESTS=ON",
+    "-DCPP_COMMON_UTILS_BUILD_TESTS=ON",
     // "-DCMAKE_TOOLCHAIN_FILE=/home/sinter/softwares/android-ndk-r27c/build/cmake/android.toolchain.cmake",
     // "-DANDROID_ABI=arm64-v8a",
     // "-DANDROID_PLATFORM=android-24",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,11 +5,11 @@ PROJECT(CppCommonUtils VERSION 1.0.0 LANGUAGES CXX)
 
 SET(CMAKE_CXX_STANDARD 20)
 
-OPTION(BUILD_TESTS "Build with tests" OFF)
+OPTION(CPP_COMMON_UTILS_BUILD_TESTS "Build with tests for CppCommonUtils" OFF)
 
 MESSAGE(INFO "--------------------------------")
 MESSAGE(STATUS "Build CppCommonUtils: ${AI_WORKFLOW_VERSION}")
-MESSAGE(STATUS "Build with tests: ${BUILD_TESTS}")
+MESSAGE(STATUS "Build with tests for CppCommonUtils: ${CPP_COMMON_UTILS_BUILD_TESTS}")
 MESSAGE(STATUS "CMAKE_INSTALL_PREFIX: ${CMAKE_INSTALL_PREFIX}")
 MESSAGE(STATUS "CMAKE_CXX_STANDARD: ${CMAKE_CXX_STANDARD}")
 
@@ -66,7 +66,7 @@ ADD_SUBDIRECTORY(3rdparty)
 MESSAGE(INFO "--------------------------------")
 ADD_SUBDIRECTORY(src)
 
-IF(BUILD_TESTS)
+IF(CPP_COMMON_UTILS_BUILD_TESTS)
     enable_testing() # Enable testing framework
     MESSAGE(INFO "--------------------------------")
     ADD_SUBDIRECTORY(tests)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,15 +19,15 @@ MESSAGE(STATUS "APP SOURCES: ${CURRENT_DIR_SRCS}")
 SET(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_OUTPUT_DIR}/bin/tests)
 FILE(MAKE_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}) # Ensure the directory exists
 
-ADD_EXECUTABLE(main ${CURRENT_DIR_SRCS})
+ADD_EXECUTABLE(cpp_common_utils_tests ${CURRENT_DIR_SRCS})
 # No need for target_include_directories for common_utils, it's handled by target_link_libraries.
 # If there were other specific include directories for tests, they would go here.
 # No need for target_include_directories for common_utils, it's handled by target_link_libraries.
 # If there were other specific include directories for tests, they would go here.
-TARGET_LINK_LIBRARIES(main PRIVATE ${DEPENDENCY_LIBS})
+TARGET_LINK_LIBRARIES(cpp_common_utils_tests PRIVATE ${DEPENDENCY_LIBS})
 
 # Discover and add tests to CTest
 include(GoogleTest)
-gtest_discover_tests(main)
+gtest_discover_tests(cpp_common_utils_tests)
 
-INSTALL(TARGETS main DESTINATION tests) # Installs test executable to <prefix>/tests
+INSTALL(TARGETS cpp_common_utils_tests DESTINATION tests) # Installs test executable to <prefix>/tests


### PR DESCRIPTION
Renamed the BUILD_TESTS option to CPP_COMMON_UTILS_BUILD_TESTS to prevent conflicts when this project is used as a submodule.

Also renamed the test executable target from 'main' to 'cpp_common_utils_tests' to avoid potential clashes with parent project targets.